### PR TITLE
Add Jest tests for JWT service

### DIFF
--- a/grpc-manager/jest.config.js
+++ b/grpc-manager/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.test.ts']
+};

--- a/grpc-manager/package.json
+++ b/grpc-manager/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/grpcServer.js",
-    "dev": "ts-node src/grpcServer.ts"
+    "dev": "ts-node src/grpcServer.ts",
+    "test": "jest"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.8.13",
@@ -19,6 +20,9 @@
     "ts-node": "^10.9.2",
     "@types/node": "^20.9.0",
     "@types/uuid": "^10.0.0",
-    "@types/jsonwebtoken": "^9.0.9"
+    "@types/jsonwebtoken": "^9.0.9",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.12"
   }
 }

--- a/grpc-manager/test/jwtService.test.ts
+++ b/grpc-manager/test/jwtService.test.ts
@@ -1,0 +1,18 @@
+import { tokenManager } from '../src/service/jwtService';
+
+describe('tokenManager', () => {
+  it('generateToken returns a token string', () => {
+    const payload = { uuid: '123', email: 'test@example.com', name: 'Test' };
+    const token = tokenManager.generateToken(payload);
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  it('verifyToken validates token and returns original payload', () => {
+    const payload = { uuid: '123', email: 'test@example.com', name: 'Test' };
+    const token = tokenManager.generateToken(payload);
+    const result = tokenManager.verifyToken(token);
+    expect(result.valid).toBe(true);
+    expect(result.payload).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and ts-jest setup in `grpc-manager`
- create `jwtService.test.ts` to validate token generation and verification

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417e1e0b508320823d6afb0974f2ee